### PR TITLE
feat: add busybox and others to chroot

### DIFF
--- a/atoms_core/entities/distributions/almalinux.py
+++ b/atoms_core/entities/distributions/almalinux.py
@@ -9,7 +9,7 @@ class AlmaLinux(AtomDistribution, RpmDistribution, CommonDistribution):
             distribution_id="almalinux",
             name="AlmaLinux",
             logo="almalinux-symbolic",
-            releases=["9", ],
+            releases=["9", "8"],
             remote_structure=None,
             remote_hash_structure=None,
             remote_hash_type="sha256",

--- a/atoms_core/entities/distributions/alpinelinux.py
+++ b/atoms_core/entities/distributions/alpinelinux.py
@@ -8,7 +8,7 @@ class AlpineLinux(AtomDistribution, CommonDistribution):
             distribution_id="alpinelinux",
             name="Alpine Linux",
             logo="alpine-linux-symbolic",
-            releases=["3.16.1", "3.16.0"],
+            releases=["3.16.1", "3.16.2"],
             remote_structure="https://dl-cdn.alpinelinux.org/alpine/v{0}/releases/{1}/alpine-minirootfs-{2}-{1}.tar.gz",
             remote_hash_structure="https://dl-cdn.alpinelinux.org/alpine/v{0}/releases/{1}/alpine-minirootfs-{2}-{1}.tar.gz.sha256",
             remote_hash_type="sha256",

--- a/atoms_core/entities/distributions/busybox.py
+++ b/atoms_core/entities/distributions/busybox.py
@@ -1,27 +1,25 @@
 from atoms_core.entities.distribution import AtomDistribution
-from atoms_core.entities.distributions.helpers.rpm import RpmDistribution
 from atoms_core.entities.distributions.helpers.common import CommonDistribution
 
 
-class Centos(AtomDistribution, RpmDistribution, CommonDistribution):
+class Busybox(AtomDistribution, CommonDistribution):
     def __init__(self):
         super().__init__(
-            distribution_id="centos",
-            name="Centos Stream",
-            logo="centos-symbolic",
-            releases=["9-Stream", "8-Stream"],
+            distribution_id="busybox",
+            name="Busybox",
+            logo="busybox-symbolic",
+            releases=["1.34.1"],
             remote_structure=None,
             remote_hash_structure=None,
             remote_hash_type="sha256",
             architectures={"x86_64": "amd64"},
             root="",
-            container_image_name="centos",
-            default_cmd=["bash", "--login"],
-            motd=self._rpm_motd("Centos")
+            container_image_name="busybox",
+            default_cmd=["ash", "--login"],
         )
 
     def __get_base_path(self, architecture: str, release: str) -> str:
-        base_url = "https://uk.lxd.images.canonical.com/images/centos/{release}/{architecture}/default".format(
+        base_url = "https://uk.lxd.images.canonical.com/images/busybox/{release}/{architecture}/default".format(
             release=release, architecture=architecture
         )
         build = self._get_latest_remote_dir(base_url)
@@ -34,8 +32,5 @@ class Centos(AtomDistribution, RpmDistribution, CommonDistribution):
         return "{0}/SHA256SUMS".format(self.__get_base_path(architecture, release))
 
     def post_unpack(self, chroot: str):
-        # workaround Code:RPM_UNPK_NO_PERM
-        self.set_macros(chroot)
-
         # share/fake current user
         self.set_current_user(chroot)

--- a/atoms_core/entities/distributions/debian.py
+++ b/atoms_core/entities/distributions/debian.py
@@ -8,7 +8,7 @@ class Debian(AtomDistribution, CommonDistribution):
             distribution_id="debian",
             name="Debian",
             logo="debian-symbolic",
-            releases=["bullseye", "buster"],
+            releases=["bullseye", "buster", "sid"],
             remote_structure=None,
             remote_hash_structure=None,
             remote_hash_type="sha256",

--- a/atoms_core/entities/distributions/opensuse.py
+++ b/atoms_core/entities/distributions/opensuse.py
@@ -9,7 +9,7 @@ class OpenSuse(AtomDistribution, RpmDistribution, CommonDistribution):
             distribution_id="opensuse",
             name="OpenSUSE",
             logo="opensuse-symbolic",
-            releases=["Leap_15.1"],
+            releases=["Leap_15.4"],
             remote_structure="https://download.opensuse.org/repositories/Cloud:/Images:/{0}/images/openSUSE-{2}-OpenStack-rootfs.{1}.tar.xz",
             remote_hash_structure="https://download.opensuse.org/repositories/Cloud:/Images:/{0}/images/openSUSE-{2}-OpenStack-rootfs.{1}.tar.xz.sha256",
             remote_hash_type="sha256",

--- a/atoms_core/entities/distributions/ubuntu.py
+++ b/atoms_core/entities/distributions/ubuntu.py
@@ -10,7 +10,7 @@ class Ubuntu(AtomDistribution, CommonDistribution):
             distribution_id="ubuntu",
             name="Ubuntu",
             logo="ubuntu-symbolic",
-            releases=["jammy"],
+            releases=["jammy", "focal", "devel"],
             remote_structure=None,
             remote_hash_structure=None,
             remote_hash_type="sha256",


### PR DESCRIPTION
Note: this **Requires** a new icon for busybox named `busybox-symbolic` before this can be merged!
Also this PR adds more linux distro versions like adding `devel` dist to Ubuntu for example.