### PR TITLE
feat(fedora.py): add F37 to list

### DIFF
--- a/atoms_core/entities/distributions/fedora.py
+++ b/atoms_core/entities/distributions/fedora.py
@@ -9,7 +9,7 @@ class Fedora(AtomDistribution, RpmDistribution, CommonDistribution):
             distribution_id="fedora",
             name="Fedora",
             logo="fedora-symbolic",
-            releases=["36"],
+            releases=["36", "37"],
             remote_structure=None,
             remote_hash_structure=None,
             remote_hash_type="sha256",


### PR DESCRIPTION
Since Fedora 37 has been added, this needs to be updated.